### PR TITLE
Add stable burner chat tests and early session features

### DIFF
--- a/marketing/src/pages/commercial.astro
+++ b/marketing/src/pages/commercial.astro
@@ -1,5 +1,6 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import '../index.css';
 import { getLangFromUrl, useTranslations } from '../utils/i18n';
 
 const { lang: propLang } = Astro.props;

--- a/marketing/src/pages/hall-of-fame.astro
+++ b/marketing/src/pages/hall-of-fame.astro
@@ -1,5 +1,6 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import '../index.css';
 import { getLangFromUrl, useTranslations } from '../utils/i18n';
 
 const { lang: propLang } = Astro.props;

--- a/marketing/src/pages/help.astro
+++ b/marketing/src/pages/help.astro
@@ -1,5 +1,6 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import '../index.css';
 import { getLangFromUrl, useTranslations } from '../utils/i18n';
 import { 
   FiChevronLeft, FiHelpCircle, FiRefreshCw, 

--- a/marketing/src/pages/index.astro
+++ b/marketing/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import '../index.css';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import { getLangFromUrl, useTranslations } from '../utils/i18n';
 import { FiGithub, FiUserPlus, FiMessageSquare, FiShield, FiArrowRight, FiHash, FiEyeOff, FiCheck, FiX, FiCpu, FiSun, FiMoon } from 'react-icons/fi';

--- a/marketing/src/pages/privacy.astro
+++ b/marketing/src/pages/privacy.astro
@@ -1,5 +1,6 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import '../index.css';
 import { getLangFromUrl, useTranslations } from '../utils/i18n';
 import { FiArrowLeft, FiShield, FiLock, FiDatabase, FiCpu, FiGlobe, FiAlertTriangle } from 'react-icons/fi';
 

--- a/marketing/src/pages/security.astro
+++ b/marketing/src/pages/security.astro
@@ -1,5 +1,6 @@
 ---
 import MainLayout from '../layouts/MainLayout.astro';
+import '../index.css';
 import { getLangFromUrl, useTranslations } from '../utils/i18n';
 
 const { lang: propLang } = Astro.props;

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -27,7 +27,7 @@ export const MinimalUserSchema = z.object({
 export const MinimalConversationSchema = z.object({
   id: ConversationIdSchema,
   isGroup: z.boolean().default(false),
-  encryptedMetadata: Base64StringSchema.nullable().optional(),
+  encryptedMetadata: PayloadStringSchema.nullable().optional(),
   creatorId: UserIdSchema.nullable().optional(),
   updatedAt: z.preprocess((val) => { if (val == null) return undefined; try { const d = new Date(val as string | number | Date); return isNaN(d.getTime()) ? undefined : d.toISOString(); } catch { return undefined; } }, z.string().optional()),
   unreadCount: z.number().default(0),

--- a/packages/shared/src/socket.ts
+++ b/packages/shared/src/socket.ts
@@ -140,6 +140,7 @@ export interface ServerToClientEvents {
     "migration:ack": (payload: { roomId: string; success: boolean }) => void;
     'message:deleted_remotely': (payload: { messageId: string; conversationId: string; deletedBy: string }) => void;
     "burner:receive": (payload: { roomId: string; ciphertext: string }) => void;
+    "burner:terminated": (payload: { roomId: string }) => void;
 }
 
 export interface ClientToServerEvents {
@@ -173,4 +174,7 @@ export interface ClientToServerEvents {
     'message:unsend': (payload: { messageId: string; conversationId: string }) => void;
     'message:view_once_opened': (payload: { messageId: string; conversationId: string }) => void;
     "burner:send": (payload: { roomId: string; targetDeviceId: string; ciphertext: string; hostUserId: string }, callback: (res: { ok: boolean; error?: string }) => void) => void;
+    "burner:join": (payload: { roomId: string }) => void;
+    "burner:reply": (payload: { roomId: string; ciphertext: string }) => void;
+    "burner:destroy": (payload: { roomId: string }) => void;
 }

--- a/packages/shared/src/socket.ts
+++ b/packages/shared/src/socket.ts
@@ -139,6 +139,7 @@ export interface ServerToClientEvents {
     "migration:chunk": (payload: { roomId: string; chunkIndex: number; chunk: ArrayBuffer }) => void;
     "migration:ack": (payload: { roomId: string; success: boolean }) => void;
     'message:deleted_remotely': (payload: { messageId: string; conversationId: string; deletedBy: string }) => void;
+    "burner:receive": (payload: { roomId: string; ciphertext: string }) => void;
 }
 
 export interface ClientToServerEvents {
@@ -171,4 +172,5 @@ export interface ClientToServerEvents {
     "migration:ack": (payload: { roomId: string; success: boolean }) => void;
     'message:unsend': (payload: { messageId: string; conversationId: string }) => void;
     'message:view_once_opened': (payload: { messageId: string; conversationId: string }) => void;
+    "burner:send": (payload: { roomId: string; targetDeviceId: string; ciphertext: string; hostUserId: string }, callback: (res: { ok: boolean; error?: string }) => void) => void;
 }

--- a/server/src/routes/uploads.ts
+++ b/server/src/routes/uploads.ts
@@ -87,6 +87,58 @@ router.post('/presigned', requireAuth, uploadLimiter, async (req, res, next) => 
   }
 })
 
+// === 0.1 BURNER CHAT PRESIGNED URL (ANONYMOUS) ===
+router.post('/burner-presigned', uploadLimiter, async (req, res, next) => {
+  try {
+    const { fileName, fileType, folder } = req.body
+
+    if (!fileName || !fileType || folder !== 'attachments') {
+      return res.status(400).json({ error: 'Missing required fields or invalid folder for burner' })
+    }
+
+    if (fileType !== 'application/octet-stream') {
+      return res.status(400).json({ error: "Protocol violation: Only encrypted 'application/octet-stream' payloads are permitted." })
+    }
+
+    const fileSize = req.body.fileSize ? parseInt(req.body.fileSize, 10) : 0
+    if (fileSize > 0) {
+      const ATTACHMENT_LIMIT = 50 * 1024 * 1024; // 50 MB max for burner
+      const ENCRYPTION_OVERHEAD = 1024; 
+      const allowedMax = ATTACHMENT_LIMIT + ENCRYPTION_OVERHEAD;
+
+      if (fileSize > allowedMax) {
+        return res.status(400).json({
+          error: `Payload too large. Maximum size is 50MB.`
+        })
+      }
+    }
+
+    const ext = fileName.split('.').pop()?.toLowerCase()
+    if (!ext) {
+      return res.status(400).json({ error: 'File extension not found in filename' })
+    }
+
+    let deleteAt: Date | undefined;
+    const fileRetention = req.body.fileRetention ? parseInt(req.body.fileRetention, 10) : 0;
+    if (fileRetention > 0) {
+      deleteAt = new Date();
+      deleteAt.setSeconds(deleteAt.getSeconds() + fileRetention);
+    }
+
+    const key = `burner/${nanoid()}.${ext}`
+    const uploadUrl = await getPresignedUploadUrl(key, 'application/octet-stream', 300, deleteAt)
+
+    res.json({
+      uploadUrl,
+      key,
+      publicUrl: `${env.r2PublicDomain}/${key}`
+    })
+  } catch (error) {
+    console.error('[PRESIGNED-URL-ERROR] Failed to generate Burner URL')
+    next(error)
+  }
+})
+
 // User avatars are now E2E Encrypted and updated via PUT /api/users/me along with the profile.
 // The server cannot decrypt the profile to extract the old avatar URL, so client must handle garbage collection or rely on orphaned file cleanup.
 

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -266,6 +266,43 @@ export function registerSocket(httpServer: HttpServer) {
       }
     });
 
+    socket.on('burner:send', async (payload: { roomId: string, targetDeviceId: string, ciphertext: string, hostUserId: string }, callback) => {
+        // Guest mengirim pesan. Kita tahu hostUserId dari metadata link.
+        if (!payload.targetDeviceId || !payload.hostUserId) {
+            return callback?.({ ok: false, error: "Invalid burner routing metadata" });
+        }
+
+        try {
+            // Ambil semua socket yang terhubung dengan akun Host
+            const targetSockets = await io.in(payload.hostUserId).fetchSockets();
+            let delivered = false;
+
+            for (const s of targetSockets) {
+                const authSocket = s as unknown as AuthenticatedSocket;
+                
+                // SECURITY GATE: "TIED-TO-DEVICE"
+                // Pastikan deviceId yang aktif di socket ini SAMA PERSIS dengan 
+                // deviceId Host pencipta Burner Link
+                if (authSocket.user?.deviceId === payload.targetDeviceId) {
+                    authSocket.emit('burner:receive', {
+                        roomId: payload.roomId,
+                        ciphertext: payload.ciphertext
+                    });
+                    delivered = true;
+                }
+            }
+
+            if (delivered) {
+                callback?.({ ok: true });
+            } else {
+                callback?.({ ok: false, error: "Host device is offline or unavailable." });
+            }
+
+        } catch (e) {
+            callback?.({ ok: false, error: "Routing failed." });
+        }
+    });
+
     socket.on('message:send', async (message: MessageSendPayload, callback: (res: { ok: boolean, msg?: RawServerMessage, error?: string }) => void) => {
       const user = await prisma.user.findUnique({ where: { id: userId }, select: { isVerified: true } });
 

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -152,6 +152,53 @@ export function registerSocket(httpServer: HttpServer) {
   io.on("connection", async (socket: AuthenticatedSocket) => {
     const userId = socket.user?.id;
 
+    // BURNER EVENTS (Accessible to both unauth Guests and auth Hosts)
+    socket.on('burner:join', (payload: { roomId: string }) => {
+      if (payload && payload.roomId && typeof payload.roomId === 'string') {
+        socket.join(payload.roomId);
+      }
+    });
+
+    socket.on('burner:send', async (payload: { roomId: string, targetDeviceId: string, ciphertext: string, hostUserId: string }, callback) => {
+        if (!payload.targetDeviceId || !payload.hostUserId) {
+            return callback?.({ ok: false, error: "Invalid burner routing metadata" });
+        }
+        try {
+            const targetSockets = await io.in(payload.hostUserId).fetchSockets();
+            let delivered = false;
+            for (const s of targetSockets) {
+                const authSocket = s as unknown as AuthenticatedSocket;
+                if (authSocket.user?.deviceId === payload.targetDeviceId) {
+                    authSocket.emit('burner:receive', {
+                        roomId: payload.roomId,
+                        ciphertext: payload.ciphertext
+                    });
+                    delivered = true;
+                }
+            }
+            if (delivered) {
+                callback?.({ ok: true });
+            } else {
+                callback?.({ ok: false, error: "Host device is offline or unavailable." });
+            }
+        } catch (e) {
+            callback?.({ ok: false, error: "Routing failed." });
+        }
+    });
+
+    socket.on('burner:reply', (payload: { roomId: string, ciphertext: string }) => {
+        if (payload?.roomId && payload?.ciphertext) {
+            io.to(payload.roomId).emit('burner:receive', { roomId: payload.roomId, ciphertext: payload.ciphertext });
+        }
+    });
+
+    socket.on('burner:destroy', (payload: { roomId: string }) => {
+        if (payload?.roomId) {
+            io.to(payload.roomId).emit('burner:terminated', { roomId: payload.roomId });
+            io.in(payload.roomId).socketsLeave(payload.roomId);
+        }
+    });
+
     if (!userId) {
       socket.on("auth:request_linking_qr", async (payload: { publicKey: string }, callback) => {
          const sodium = await getSodium();
@@ -264,43 +311,6 @@ export function registerSocket(httpServer: HttpServer) {
       } catch (error) {
         console.error(`[Key Distribution] Error:`, error);
       }
-    });
-
-    socket.on('burner:send', async (payload: { roomId: string, targetDeviceId: string, ciphertext: string, hostUserId: string }, callback) => {
-        // Guest mengirim pesan. Kita tahu hostUserId dari metadata link.
-        if (!payload.targetDeviceId || !payload.hostUserId) {
-            return callback?.({ ok: false, error: "Invalid burner routing metadata" });
-        }
-
-        try {
-            // Ambil semua socket yang terhubung dengan akun Host
-            const targetSockets = await io.in(payload.hostUserId).fetchSockets();
-            let delivered = false;
-
-            for (const s of targetSockets) {
-                const authSocket = s as unknown as AuthenticatedSocket;
-                
-                // SECURITY GATE: "TIED-TO-DEVICE"
-                // Pastikan deviceId yang aktif di socket ini SAMA PERSIS dengan 
-                // deviceId Host pencipta Burner Link
-                if (authSocket.user?.deviceId === payload.targetDeviceId) {
-                    authSocket.emit('burner:receive', {
-                        roomId: payload.roomId,
-                        ciphertext: payload.ciphertext
-                    });
-                    delivered = true;
-                }
-            }
-
-            if (delivered) {
-                callback?.({ ok: true });
-            } else {
-                callback?.({ ok: false, error: "Host device is offline or unavailable." });
-            }
-
-        } catch (e) {
-            callback?.({ ok: false, error: "Routing failed." });
-        }
     });
 
     socket.on('message:send', async (message: MessageSendPayload, callback: (res: { ok: boolean, msg?: RawServerMessage, error?: string }) => void) => {

--- a/server/src/socket.ts
+++ b/server/src/socket.ts
@@ -12,6 +12,8 @@ import { AuthPayload } from "./types/auth.js";
 import cookie from "cookie"; 
 import { getSodium } from "./lib/sodium.js";
 
+const terminatedBurners = new Set<string>();
+
 // --- REDIS ADAPTER IMPORTS ---
 import { createClient } from "redis";
 import { createAdapter } from "@socket.io/redis-adapter";
@@ -155,6 +157,10 @@ export function registerSocket(httpServer: HttpServer) {
     // BURNER EVENTS (Accessible to both unauth Guests and auth Hosts)
     socket.on('burner:join', (payload: { roomId: string }) => {
       if (payload && payload.roomId && typeof payload.roomId === 'string') {
+        if (terminatedBurners.has(payload.roomId)) {
+          socket.emit('burner:terminated', { roomId: payload.roomId });
+          return;
+        }
         socket.join(payload.roomId);
       }
     });
@@ -162,6 +168,9 @@ export function registerSocket(httpServer: HttpServer) {
     socket.on('burner:send', async (payload: { roomId: string, targetDeviceId: string, ciphertext: string, hostUserId: string }, callback) => {
         if (!payload.targetDeviceId || !payload.hostUserId) {
             return callback?.({ ok: false, error: "Invalid burner routing metadata" });
+        }
+        if (terminatedBurners.has(payload.roomId)) {
+            return callback?.({ ok: false, error: "Room has been terminated." });
         }
         try {
             const targetSockets = await io.in(payload.hostUserId).fetchSockets();
@@ -188,12 +197,14 @@ export function registerSocket(httpServer: HttpServer) {
 
     socket.on('burner:reply', (payload: { roomId: string, ciphertext: string }) => {
         if (payload?.roomId && payload?.ciphertext) {
+            if (terminatedBurners.has(payload.roomId)) return;
             io.to(payload.roomId).emit('burner:receive', { roomId: payload.roomId, ciphertext: payload.ciphertext });
         }
     });
 
     socket.on('burner:destroy', (payload: { roomId: string }) => {
         if (payload?.roomId) {
+            terminatedBurners.add(payload.roomId);
             io.to(payload.roomId).emit('burner:terminated', { roomId: payload.roomId });
             io.in(payload.roomId).socketsLeave(payload.roomId);
         }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ const MigrationReceivePage = lazy(() => import('./pages/MigrationReceivePage'));
 const MigrationSendPage = lazy(() => import('./pages/MigrationSendPage'));
 const ConnectPage = lazy(() => import('./pages/ConnectPage'));
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
+const BurnerChat = lazy(() => import('./pages/BurnerChat'));
 
 // Components
 import ProtectedRoute from './components/ProtectedRoute';
@@ -176,15 +177,19 @@ const AppContent = () => {
   // 1. Bootstrap Auth
   useEffect(() => {
     const initAuth = async () => {
-      await bootstrap();
-      
-      const { user, accessToken, silentRefresh, logout } = useAuthStore.getState();
-      // If we think we are logged in, but we don't have an AT
-      if (user && !accessToken) {
-        const success = await silentRefresh();
-        if (!success) {
-            logout();
+      try {
+        await bootstrap();
+        
+        const { user, accessToken, silentRefresh, logout } = useAuthStore.getState();
+        // If we think we are logged in, but we don't have an AT
+        if (user && !accessToken) {
+          const success = await silentRefresh();
+          if (!success) {
+              logout();
+          }
         }
+      } catch (e) {
+        console.log("Bootstrap error (normal for guests):", e);
       }
     };
     initAuth();
@@ -206,7 +211,10 @@ const AppContent = () => {
         });
       }
     } else {
-      disconnectSocket();
+      // Don't disconnect if on Burner Chat drop route (guest needs it)
+      if (location.pathname !== '/drop') {
+         disconnectSocket();
+      }
     }
   }, [user, location.pathname, isDeviceFlow]);
 
@@ -336,6 +344,7 @@ const AppContent = () => {
             />
             <Route path="/restore" element={<PageWrapper><Restore /></PageWrapper>} />
             <Route path="/migrate-receive" element={<PageWrapper><MigrationReceivePage /></PageWrapper>} />
+            <Route path="/drop" element={<PageWrapper noScroll={true}><BurnerChat /></PageWrapper>} />
 
             {/* Protected Routes */}
             <Route element={<ProtectedRoute />}>

--- a/web/src/components/ChatList.tsx
+++ b/web/src/components/ChatList.tsx
@@ -16,10 +16,11 @@ import type { Conversation } from '@store/conversation';
 
 import { toAbsoluteUrl } from '@utils/url';
 
-import { FiUsers, FiSearch, FiSettings, FiLogOut, FiUser, FiMaximize2, FiSlash, FiTrash2, FiEye, FiEyeOff, FiLock } from 'react-icons/fi';
+import { FiUsers, FiSearch, FiSettings, FiLogOut, FiUser, FiMaximize2, FiSlash, FiTrash2, FiEye, FiEyeOff, FiLock, FiZap } from 'react-icons/fi';
 import { BiQrScan } from 'react-icons/bi';
 
 import CreateGroupChat from './CreateGroupChat';
+import CreateBurnerModal from './CreateBurnerModal';
 import ScanQRModal from './ScanQRModal';
 import ShareProfileModal from './ShareProfileModal';
 import NotificationBell from './NotificationBell';
@@ -422,6 +423,7 @@ export default function ChatList() {
   })));
 
   const [showGroupModal, setShowGroupModal] = useState(false);
+  const [showBurnerModal, setShowBurnerModal] = useState(false);
   const [showScanModal, setShowScanModal] = useState(false);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const { addCommands, removeCommands } = useCommandPaletteStore(useShallow(s => ({
@@ -430,15 +432,22 @@ export default function ChatList() {
   const privacyCloak = useSettingsStore(s => s.privacyCloak);
 
   const openCreateGroupModal = useCallback(() => setShowGroupModal(true), []);
+  const handleCreateBurner = useCallback(() => setShowBurnerModal(true), []);
 
   useEffect(() => {
-    const commands = [{
-      id: 'new-group', name: t('chat:sidebar.new_group'), action: openCreateGroupModal,
-      icon: <FiUsers />, section: 'General', keywords: 'create group chat conversation',
-    }];
+    const commands = [
+      {
+        id: 'new-group', name: t('chat:sidebar.new_group'), action: openCreateGroupModal,
+        icon: <FiUsers />, section: 'General', keywords: 'create group chat conversation',
+      },
+      {
+        id: 'new-burner', name: t('chat:sidebar.new_burner', 'New Burner Chat'), action: handleCreateBurner,
+        icon: <FiZap />, section: 'General', keywords: 'create burner temporary secure incognito',
+      }
+    ];
     addCommands(commands);
     return () => removeCommands(commands.map(c => c.id));
-  }, [addCommands, removeCommands, openCreateGroupModal, t]);
+  }, [addCommands, removeCommands, openCreateGroupModal, handleCreateBurner, t]);
 
   const itemContent = useCallback((index: number, c: Conversation) => {
     const peerUser = !c.isGroup ? c.participants?.find(p => p.id !== meId) : null;
@@ -507,6 +516,17 @@ export default function ChatList() {
               <BiQrScan size={18} />
             </button>
             <button 
+              onClick={handleCreateBurner} 
+              title={t('chat:sidebar.new_burner', 'Create Burner Link')}
+              aria-label={t('chat:sidebar.new_burner', 'Create Burner Link')}
+              className="
+                p-2 rounded-full text-text-secondary
+                hover:text-accent active:scale-95 transition-all
+              "
+            >
+              <FiZap size={20} />
+            </button>
+            <button 
               onClick={openCreateGroupModal} 
               title={t('chat:sidebar.new_group')}
               aria-label={t('chat:sidebar.new_group')}
@@ -567,6 +587,7 @@ export default function ChatList() {
       </div>
       
       {showGroupModal && <CreateGroupChat onClose={() => setShowGroupModal(false)} />}
+      {showBurnerModal && <CreateBurnerModal onClose={() => setShowBurnerModal(false)} />}
       {showScanModal && (
         <ScanQRModal 
           onClose={() => setShowScanModal(false)} 

--- a/web/src/components/ChatWindow.tsx
+++ b/web/src/components/ChatWindow.tsx
@@ -117,6 +117,15 @@ const ChatHeader = ({ conversation, onBack, onInfoToggle, onMenuClick }: { conve
     }
   };
 
+  const isBurner = conversation.id.startsWith('burner_');
+
+  const handleDestroyBurner = async () => {
+    const { useBurnerStore } = await import('@store/burner');
+    useBurnerStore.getState().destroyBurnerSession(conversation.id);
+    import('react-hot-toast').then(m => m.default.success("Burner Session Destroyed"));
+    useConversationStore.getState().openConversation(null);
+  };
+
   return (
     <div className="
       flex items-center justify-between px-4 py-3 z-30
@@ -180,7 +189,17 @@ const ChatHeader = ({ conversation, onBack, onInfoToggle, onMenuClick }: { conve
 
       {/* Action Module */}
       <div className="flex items-center gap-2 md:gap-3">
-        {!conversation.isGroup && (
+        {isBurner && (
+          <button
+            onClick={handleDestroyBurner}
+            aria-label="Destroy Burner Session"
+            className="flex items-center justify-center px-3 h-9 rounded-full bg-red-500/10 text-red-500 hover:bg-red-500/20 active:bg-red-500/30 transition-all duration-200 border border-red-500/20 text-xs font-bold uppercase tracking-wider"
+          >
+            Destroy
+          </button>
+        )}
+        
+        {!conversation.isGroup && !isBurner && (
           <>
             <button
               onClick={handleVoiceCall}

--- a/web/src/components/CreateBurnerModal.tsx
+++ b/web/src/components/CreateBurnerModal.tsx
@@ -1,0 +1,114 @@
+import { FiX, FiCopy, FiCheck, FiZap } from 'react-icons/fi';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function CreateBurnerModal({ onClose }: Props) {
+  const { t } = useTranslation(['modals', 'common']);
+  const [copied, setCopied] = useState(false);
+  const [link, setLink] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    const generate = async () => {
+      try {
+        const { generateBurnerLink } = await import('@store/burner');
+        const generatedLink = await generateBurnerLink();
+        if (mounted) {
+          setLink(generatedLink);
+          setIsGenerating(false);
+        }
+      } catch (e) {
+        console.error(e);
+        if (mounted) {
+          setError('Failed to generate secure burner link.');
+          setIsGenerating(false);
+        }
+      }
+    };
+    generate();
+    return () => { mounted = false; };
+  }, []);
+
+  const handleCopy = async () => {
+    if (!link) return;
+    try {
+      await navigator.clipboard.writeText(link);
+      setCopied(true);
+      toast.success('Burner Chat link copied!');
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error('Failed to copy link');
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div 
+        initial={{ opacity: 0 }} 
+        animate={{ opacity: 1 }} 
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 z-[100] bg-black/80 backdrop-blur-sm flex items-center justify-center p-4"
+        onClick={onClose}
+      >
+        <motion.div 
+          initial={{ scale: 0.95, y: 20 }} 
+          animate={{ scale: 1, y: 0 }}
+          exit={{ scale: 0.95, y: 20 }}
+          onClick={(e) => e.stopPropagation()}
+          className="bg-bg-surface border border-white/10 rounded-2xl p-6 max-w-sm w-full shadow-2xl relative"
+        >
+          <button 
+            onClick={onClose}
+            className="absolute top-4 right-4 p-2 text-text-secondary hover:text-white bg-black/20 rounded-full hover:bg-black/40 transition-colors"
+          >
+            <FiX size={20} />
+          </button>
+
+          <div className="text-center mb-6 mt-2">
+            <div className="mx-auto w-12 h-12 rounded-full bg-accent/20 text-accent flex items-center justify-center mb-4">
+              <FiZap size={24} />
+            </div>
+            <h2 className="text-xl font-black uppercase tracking-widest text-text-primary">Burner Chat</h2>
+            <p className="text-xs text-text-secondary mt-2 font-mono leading-relaxed">
+              Generate a one-time, post-quantum encrypted ephemeral chat link. Data exists only in RAM.
+            </p>
+          </div>
+
+          <div className="bg-bg-main p-4 rounded-xl flex items-center justify-center mx-auto w-full mb-6 border border-border">
+            {isGenerating ? (
+              <div className="flex items-center gap-3 text-text-secondary">
+                 <div className="w-4 h-4 border-2 border-accent border-t-transparent rounded-full animate-spin"></div>
+                 <span className="text-sm font-mono">Provisioning keys...</span>
+              </div>
+            ) : error ? (
+              <span className="text-sm font-mono text-red-500">{error}</span>
+            ) : (
+              <div className="w-full relative">
+                 <div className="text-xs font-mono text-text-secondary break-all truncate overflow-hidden whitespace-nowrap opacity-60 px-2">
+                    {link}
+                 </div>
+              </div>
+            )}
+          </div>
+
+          <button 
+            onClick={handleCopy}
+            disabled={isGenerating || !!error}
+            className="w-full py-3 rounded-xl bg-accent text-white font-bold uppercase tracking-wider hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2 shadow-neu-flat-light dark:shadow-neu-flat-dark"
+          >
+            {copied ? <FiCheck className="text-white" /> : <FiCopy />}
+            {copied ? 'Copied to Clipboard' : 'Copy Secure Link'}
+          </button>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/web/src/components/CreateBurnerModal.tsx
+++ b/web/src/components/CreateBurnerModal.tsx
@@ -8,6 +8,8 @@ interface Props {
   onClose: () => void;
 }
 
+import { useConversationStore } from '@store/conversation';
+
 export default function CreateBurnerModal({ onClose }: Props) {
   const { t } = useTranslation(['modals', 'common']);
   const [copied, setCopied] = useState(false);
@@ -43,6 +45,24 @@ export default function CreateBurnerModal({ onClose }: Props) {
       await navigator.clipboard.writeText(link);
       setCopied(true);
       toast.success('Burner Chat link copied!');
+
+      const hashPart = link.split('#')[1];
+      if (hashPart) {
+        const [roomId] = hashPart.split(':');
+        if (roomId) {
+           useConversationStore.getState().addOrUpdateConversation({
+             id: roomId,
+             isGroup: false,
+             participants: [],
+             messages: [],
+             unreadCount: 0,
+             createdAt: new Date().toISOString(),
+             updatedAt: new Date().toISOString(),
+             encryptedMetadata: "BURNER_CHAT"
+           } as any);
+        }
+      }
+
       setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error('Failed to copy link');

--- a/web/src/components/MessageInput.tsx
+++ b/web/src/components/MessageInput.tsx
@@ -9,6 +9,7 @@ import { useMessageInputStore } from '@store/messageInput';
 import { useConnectionStore } from '@store/connection';
 import { useAuthStore } from '@store/auth';
 import { useThemeStore } from '@store/theme';
+import { useBurnerStore } from '@store/burner';
 import LinkPreviewCard from './LinkPreviewCard';
 import SmartReply from './SmartReply';
 import { useMessageStore } from '@store/message';
@@ -169,7 +170,17 @@ export default function MessageInput({ onSend, onTyping, onVoiceSend, conversati
   const otherParticipant = isOneToOne && (conversation.participants as { id: string }[] | undefined)?.find(p => p.id !== useAuthStore.getState().user?.id);
   const isOtherParticipantBlocked = isOneToOne && otherParticipant && blockedUserIds.includes(otherParticipant.id);
   const isConnected = connectionStatus === 'connected';
-  const isInputDisabled = !isConnected || isOtherParticipantBlocked;
+  
+  const isBurner = conversation.id.startsWith('burner_');
+  const burnerSession = useBurnerStore((s: any) => s.activeSessions[conversation.id]);
+  const isWaitingForGuest = isBurner && !burnerSession?.drState && !!useAuthStore.getState().user;
+
+  const isInputDisabled = !isConnected || isOtherParticipantBlocked || isWaitingForGuest;
+
+  const getPlaceholderText = () => {
+    if (isWaitingForGuest) return "Waiting for guest to establish secure connection...";
+    return t('chat:input.placeholder');
+  };
 
   const absoluteLastMessage = messages.length > 0 ? messages[messages.length - 1] : null;
   const isLastMessageFromOther = absoluteLastMessage?.senderId !== user?.id;
@@ -558,7 +569,7 @@ export default function MessageInput({ onSend, onTyping, onVoiceSend, conversati
               type="text"
               onChange={handleTextChange}
               disabled={isInputDisabled}
-              placeholder={isConnected ? (expiresIn ? t('input.placeholder_disappearing') : t('input.placeholder_default')) : t('input.placeholder_offline')}
+              placeholder={getPlaceholderText()}
               className="w-full bg-transparent border-none outline-none text-text-primary placeholder:text-text-secondary/50 h-10 px-2 font-medium"
             />
           </div>

--- a/web/src/lib/crypto-worker-proxy.ts
+++ b/web/src/lib/crypto-worker-proxy.ts
@@ -436,3 +436,61 @@ export async function groupDecryptSkipped(
     plaintext: new Uint8Array(res.plaintext)
   }));
 }
+
+// --- BURNER PROTOCOL (PQ-DR) PROXY FUNCTIONS ---
+
+import type { BurnerDoubleRatchetState, BurnerDoubleRatchetHeader } from '../workers/crypto.worker';
+
+export function worker_burner_dr_init_guest(payload: {
+  hostClassicalPk: CryptoBuffer;
+  hostPqPk: CryptoBuffer;
+}): Promise<{ state: BurnerDoubleRatchetState; guestClassicalPk: string }> {
+  return sendToWorker<{ state: BurnerDoubleRatchetState; guestClassicalPk: string }>('burner_dr_init_guest', {
+    hostClassicalPk: toArray(payload.hostClassicalPk),
+    hostPqPk: toArray(payload.hostPqPk)
+  });
+}
+
+export function worker_burner_dr_init_host(payload: {
+  guestClassicalPk: CryptoBuffer;
+  hostClassicalSk: CryptoBuffer;
+  savedCt: CryptoBuffer;
+  hostPqSk: CryptoBuffer;
+}): Promise<{ state: BurnerDoubleRatchetState }> {
+  return sendToWorker<{ state: BurnerDoubleRatchetState }>('burner_dr_init_host', {
+    guestClassicalPk: toArray(payload.guestClassicalPk),
+    hostClassicalSk: toArray(payload.hostClassicalSk),
+    savedCt: toArray(payload.savedCt),
+    hostPqSk: toArray(payload.hostPqSk)
+  });
+}
+
+export function worker_burner_dr_encrypt(payload: {
+  state: BurnerDoubleRatchetState;
+  plaintext: string | CryptoBuffer;
+}): Promise<{ state: BurnerDoubleRatchetState; header: BurnerDoubleRatchetHeader; ciphertext: Uint8Array; mk: Uint8Array }> {
+  return sendToWorker<{ state: BurnerDoubleRatchetState; header: BurnerDoubleRatchetHeader; ciphertext: ArrayBuffer; mk: ArrayBuffer }>('burner_dr_encrypt', {
+    state: payload.state,
+    plaintext: typeof payload.plaintext === 'string' ? payload.plaintext : toArray(payload.plaintext)
+  }).then(res => ({
+    ...res,
+    ciphertext: new Uint8Array(res.ciphertext),
+    mk: new Uint8Array(res.mk)
+  }));
+}
+
+export function worker_burner_dr_decrypt(payload: {
+  state: BurnerDoubleRatchetState;
+  header: BurnerDoubleRatchetHeader;
+  ciphertext: CryptoBuffer;
+}): Promise<{ state: BurnerDoubleRatchetState; plaintext: Uint8Array; skippedKeys: { kemPk: string; n: number; mk: string }[]; mk: Uint8Array }> {
+  return sendToWorker<{ state: BurnerDoubleRatchetState; plaintext: ArrayBuffer; skippedKeys: { kemPk: string; n: number; mk: string }[]; mk: ArrayBuffer }>('burner_dr_decrypt', {
+    state: payload.state,
+    header: payload.header,
+    ciphertext: toArray(payload.ciphertext)
+  }).then(res => ({
+    ...res,
+    plaintext: new Uint8Array(res.plaintext),
+    mk: new Uint8Array(res.mk)
+  }));
+}

--- a/web/src/lib/shadowVaultDb.ts
+++ b/web/src/lib/shadowVaultDb.ts
@@ -300,6 +300,18 @@ class NyxShadowVaultProxy {
     }
   }
 
+  async deleteConversation(id: string) {
+    try {
+      await this.deleteConversationMessages(id);
+      // Clean up related crypto states if they exist
+      await db.ratchetSessions.delete(id);
+      await db.groupSenderStates.delete(id);
+      await db.groupReceiverStates.where('id').startsWith(id + '_').delete();
+    } catch (e) {
+      console.error("Failed to delete conversation data from vault", e);
+    }
+  }
+
   async deleteConversationMessages(conversationId: string) {
     try {
       await db.messages.where('conversationId').equals(conversationId).delete();

--- a/web/src/lib/socket.ts
+++ b/web/src/lib/socket.ts
@@ -250,9 +250,10 @@ export function getSocket() {
     socket.on("burner:terminated", async (payload: { roomId: string }) => {
       const { useBurnerStore } = await import('@store/burner');
       if (payload?.roomId) {
-        useBurnerStore.getState().destroyBurnerSession(payload.roomId);
-        const toast = (await import('react-hot-toast')).default;
-        toast("This secure session has been terminated by the host.", { icon: '⚠️' });
+        useBurnerStore.getState().terminateSession('This secure session has been terminated by the host.');
+        // Clean up the conversation list
+        const { useConversationStore } = await import('@store/conversation');
+        useConversationStore.getState().deleteConversation(payload.roomId);
       }
     });
 

--- a/web/src/lib/socket.ts
+++ b/web/src/lib/socket.ts
@@ -239,6 +239,23 @@ export function getSocket() {
       removeMessage(conversationId, id);
     });
 
+    socket.on("burner:receive", async (payload: { roomId?: string, ciphertext: string }) => {
+      const { useBurnerStore } = await import('@store/burner');
+      const roomId = payload.roomId || Object.keys(useBurnerStore.getState().activeSessions)[0];
+      if (roomId) {
+        await useBurnerStore.getState().receiveMessage(roomId, payload.ciphertext);
+      }
+    });
+
+    socket.on("burner:terminated", async (payload: { roomId: string }) => {
+      const { useBurnerStore } = await import('@store/burner');
+      if (payload?.roomId) {
+        useBurnerStore.getState().destroyBurnerSession(payload.roomId);
+        const toast = (await import('react-hot-toast')).default;
+        toast("This secure session has been terminated by the host.", { icon: '⚠️' });
+      }
+    });
+
     socket.on("messages:expired", ({ messageIds }: { messageIds: string[] }) => {
       const { messages, removeMessage } = useMessageStore.getState();
       const expiredSet = new Set(messageIds);

--- a/web/src/pages/BurnerChat.tsx
+++ b/web/src/pages/BurnerChat.tsx
@@ -2,18 +2,26 @@ import React, { useEffect, useState, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useBurnerStore } from '../store/burner';
 import { getSocket, connectSocket } from '../lib/socket';
+import { FiPaperclip, FiMic, FiSend } from 'react-icons/fi';
+import MessageBubble from '../components/MessageBubble';
+import type { Message } from '@nyx/shared';
+import { api } from '../lib/api';
+import toast from 'react-hot-toast';
 
 export default function BurnerChat() {
   const location = useLocation();
-  const { isInitialized, error, messages, initializeFromHash, sendMessage } = useBurnerStore();
+  const { error, messages, initializeFromHash, sendMessage, activeSessions } = useBurnerStore();
   const [inputText, setInputText] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Extract roomId from hash
+  const hashPart = location.hash.split('#')[1];
+  const roomId = hashPart ? hashPart.split(':')[0] : '';
+  const isInitialized = !!activeSessions[roomId]?.drState;
 
   useEffect(() => {
-    // If socket isn't connected (guest user not logged in), connect it manually.
-    // In NYX, if there's no JWT, socket connection still establishes but as an anonymous socket.
-    // Since Burner Chat is host-to-guest and the host relies on socket routing,
-    // the guest must be connected to the socket server.
     const socket = getSocket();
     if (!socket?.connected) {
       connectSocket();
@@ -23,6 +31,16 @@ export default function BurnerChat() {
   useEffect(() => {
     if (location.hash) {
       initializeFromHash(location.hash);
+    }
+    
+    // Explicitly join the room for anonymous guest
+    const socket = getSocket();
+    if (socket && location.hash) {
+       const hashPart = location.hash.split('#')[1];
+       if (hashPart) {
+          const [id] = hashPart.split(':');
+          socket.emit('burner:join', { roomId: id });
+       }
     }
   }, [location.hash, initializeFromHash]);
 
@@ -35,6 +53,67 @@ export default function BurnerChat() {
     if (!inputText.trim()) return;
     await sendMessage(inputText);
     setInputText('');
+  };
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    try {
+      // 1. Encrypt file using worker
+      const { encryptFileViaWorker } = await import('../utils/crypto');
+      const encryptRes = await encryptFileViaWorker(file);
+      const encryptedBlob = encryptRes.encryptedBlob;
+      const rawFileKey = encryptRes.key;
+      
+      const { getSodiumLib } = await import('../utils/crypto');
+      const sodium = await getSodiumLib();
+      const fileKeyB64 = sodium.to_base64(rawFileKey, sodium.base64_variants.URLSAFE_NO_PADDING);
+
+      // 2. Get Presigned URL
+      const presignedRes = await api<{ uploadUrl: string, publicUrl: string, key: string }>('/api/uploads/burner-presigned', {
+          method: 'POST',
+          body: JSON.stringify({
+              fileName: file.name,
+              fileType: 'application/octet-stream',
+              folder: 'attachments',
+              fileSize: encryptedBlob.size,
+              fileRetention: 0
+          })
+      });
+
+      // 3. Upload file
+      await new Promise<void>((resolve, reject) => {
+          const xhr = new XMLHttpRequest();
+          xhr.open('PUT', presignedRes.uploadUrl, true);
+          xhr.onload = () => {
+              if (xhr.status === 200) resolve();
+              else reject(new Error('Upload failed'));
+          };
+          xhr.onerror = () => reject(new Error('Upload failed'));
+          xhr.send(encryptedBlob);
+      });
+
+      // 4. Send Message JSON
+      const finalContent = JSON.stringify({
+        type: "file",
+        text: "",
+        fileUrl: presignedRes.publicUrl,
+        fileName: file.name,
+        fileType: file.type,
+        fileSize: file.size,
+        fileKey: fileKeyB64 
+      });
+
+      await sendMessage(finalContent);
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to upload file');
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
   };
 
   if (error) {
@@ -60,7 +139,7 @@ export default function BurnerChat() {
   }
 
   return (
-    <div className="flex flex-col h-full w-full bg-bg-main">
+    <div className="flex flex-col h-full w-full bg-bg-main relative">
       <header className="flex items-center justify-between p-4 border-b border-border bg-bg-surface/50 backdrop-blur-md sticky top-0 z-10">
         <div>
           <h1 className="text-lg font-bold text-text-primary flex items-center gap-2">
@@ -80,48 +159,97 @@ export default function BurnerChat() {
             <p>Session is live. Messages are ephemeral.</p>
           </div>
         ) : (
-          messages.map((msg) => (
-            <div
-              key={msg.id}
-              className={`flex ${msg.senderId === 'guest' ? 'justify-end' : 'justify-start'}`}
-            >
-              <div
-                className={`max-w-[80%] rounded-2xl px-4 py-2 ${
-                  msg.senderId === 'guest'
-                    ? 'bg-accent text-white rounded-tr-sm'
-                    : 'bg-bg-surface border border-border text-text-primary rounded-tl-sm'
-                }`}
-              >
-                <p className="break-words">{msg.content}</p>
-                <p className="text-[10px] opacity-60 mt-1 text-right">
-                  {new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                </p>
-              </div>
-            </div>
-          ))
+          messages.map((msg, index) => {
+            const isMe = msg.senderId === 'guest';
+            
+            let parsedContent = msg.content;
+            let fileUrl, fileName, fileType, fileKey, fileSize;
+            
+            try {
+               if (msg.content.startsWith('{')) {
+                  const data = JSON.parse(msg.content);
+                  if (data.type === 'file') {
+                     parsedContent = data.text || '';
+                     fileUrl = data.fileUrl;
+                     fileName = data.fileName;
+                     fileType = data.fileType;
+                     fileKey = data.fileKey;
+                     fileSize = data.fileSize;
+                  }
+               }
+            } catch(e) {}
+
+            const messageObj = {
+              id: msg.id,
+              conversationId: roomId || '',
+              senderId: msg.senderId,
+              content: parsedContent,
+              createdAt: msg.createdAt,
+              updatedAt: msg.createdAt,
+              isSilent: false,
+              isEdited: false,
+              isViewOnce: false,
+              isViewed: true,
+              fileUrl, fileName, fileType, fileKey, fileSize
+            } as unknown as Message;
+
+            return (
+              <MessageBubble 
+                key={msg.id} 
+                message={messageObj} 
+                isOwn={isMe} 
+                isLastInSequence={index === messages.length - 1}
+              />
+            );
+          })
         )}
         <div ref={messagesEndRef} />
       </main>
 
       <footer className="p-4 bg-bg-surface/50 border-t border-border">
-        <form onSubmit={handleSend} className="flex gap-2">
+        {isUploading && (
+           <div className="text-xs text-accent mb-2 px-2 animate-pulse">Uploading encrypted attachment...</div>
+        )}
+        <form onSubmit={handleSend} className="flex gap-2 items-center bg-bg-main border border-border rounded-full pr-2 pl-1 py-1">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="p-2 text-text-secondary hover:text-accent transition-colors rounded-full"
+          >
+            <FiPaperclip size={20} />
+          </button>
+          <input 
+            type="file" 
+            ref={fileInputRef} 
+            onChange={handleFileUpload} 
+            className="hidden" 
+          />
+          
           <input
             type="text"
             value={inputText}
             onChange={(e) => setInputText(e.target.value)}
             placeholder="Type an ephemeral message..."
-            className="flex-1 bg-bg-main border border-border rounded-full px-4 py-2 text-text-primary focus:outline-none focus:border-accent transition-colors"
+            className="flex-1 bg-transparent px-2 py-2 text-text-primary focus:outline-none placeholder-text-secondary/50"
             autoFocus
           />
-          <button
-            type="submit"
-            disabled={!inputText.trim()}
-            className="bg-accent hover:bg-accent/90 disabled:opacity-50 text-white rounded-full p-2 w-10 h-10 flex items-center justify-center transition-colors"
-          >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-            </svg>
-          </button>
+          
+          {inputText.trim() ? (
+            <button
+              type="submit"
+              disabled={isUploading}
+              className="bg-accent hover:bg-accent/90 disabled:opacity-50 text-white rounded-full p-2 w-10 h-10 flex items-center justify-center transition-colors"
+            >
+              <FiSend size={18} />
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="text-text-secondary hover:text-accent p-2 rounded-full transition-colors"
+            >
+              <FiMic size={20} />
+            </button>
+          )}
         </form>
       </footer>
     </div>

--- a/web/src/pages/BurnerChat.tsx
+++ b/web/src/pages/BurnerChat.tsx
@@ -10,16 +10,16 @@ import toast from 'react-hot-toast';
 
 export default function BurnerChat() {
   const location = useLocation();
-  const { error, messages, initializeFromHash, sendMessage, activeSessions } = useBurnerStore();
+  const { error, messages, isInitialized, initializeFromHash, sendMessage, activeSessions } = useBurnerStore();
   const [inputText, setInputText] = useState('');
   const [isUploading, setIsUploading] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Extract roomId from hash
+  // Extract roomId from hash for reference
   const hashPart = location.hash.split('#')[1];
   const roomId = hashPart ? hashPart.split(':')[0] : '';
-  const isInitialized = !!activeSessions[roomId]?.drState;
+  // Removed local isInitialized calculation as it's now handled by the store.
 
   useEffect(() => {
     const socket = getSocket();
@@ -67,10 +67,6 @@ export default function BurnerChat() {
       const encryptedBlob = encryptRes.encryptedBlob;
       const rawFileKey = encryptRes.key;
       
-      const { getSodiumLib } = await import('../utils/crypto');
-      const sodium = await getSodiumLib();
-      const fileKeyB64 = sodium.to_base64(rawFileKey, sodium.base64_variants.URLSAFE_NO_PADDING);
-
       // 2. Get Presigned URL
       const presignedRes = await api<{ uploadUrl: string, publicUrl: string, key: string }>('/api/uploads/burner-presigned', {
           method: 'POST',
@@ -103,7 +99,7 @@ export default function BurnerChat() {
         fileName: file.name,
         fileType: file.type,
         fileSize: file.size,
-        fileKey: fileKeyB64 
+        fileKey: rawFileKey 
       });
 
       await sendMessage(finalContent);
@@ -162,35 +158,22 @@ export default function BurnerChat() {
           messages.map((msg, index) => {
             const isMe = msg.senderId === 'guest';
             
-            let parsedContent = msg.content;
-            let fileUrl, fileName, fileType, fileKey, fileSize;
-            
-            try {
-               if (msg.content.startsWith('{')) {
-                  const data = JSON.parse(msg.content);
-                  if (data.type === 'file') {
-                     parsedContent = data.text || '';
-                     fileUrl = data.fileUrl;
-                     fileName = data.fileName;
-                     fileType = data.fileType;
-                     fileKey = data.fileKey;
-                     fileSize = data.fileSize;
-                  }
-               }
-            } catch(e) {}
-
             const messageObj = {
               id: msg.id,
               conversationId: roomId || '',
               senderId: msg.senderId,
-              content: parsedContent,
+              content: msg.content,
               createdAt: msg.createdAt,
               updatedAt: msg.createdAt,
               isSilent: false,
               isEdited: false,
               isViewOnce: false,
               isViewed: true,
-              fileUrl, fileName, fileType, fileKey, fileSize
+              fileUrl: msg.fileUrl,
+              fileName: msg.fileName,
+              fileType: msg.fileType,
+              fileKey: msg.fileKey,
+              fileSize: msg.fileSize
             } as unknown as Message;
 
             return (

--- a/web/src/pages/BurnerChat.tsx
+++ b/web/src/pages/BurnerChat.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useBurnerStore } from '../store/burner';
+import { getSocket, connectSocket } from '../lib/socket';
+
+export default function BurnerChat() {
+  const location = useLocation();
+  const { isInitialized, error, messages, initializeFromHash, sendMessage } = useBurnerStore();
+  const [inputText, setInputText] = useState('');
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // If socket isn't connected (guest user not logged in), connect it manually.
+    // In NYX, if there's no JWT, socket connection still establishes but as an anonymous socket.
+    // Since Burner Chat is host-to-guest and the host relies on socket routing,
+    // the guest must be connected to the socket server.
+    const socket = getSocket();
+    if (!socket?.connected) {
+      connectSocket();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (location.hash) {
+      initializeFromHash(location.hash);
+    }
+  }, [location.hash, initializeFromHash]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inputText.trim()) return;
+    await sendMessage(inputText);
+    setInputText('');
+  };
+
+  if (error) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-4">
+        <div className="bg-red-500/10 text-red-500 p-4 rounded-xl border border-red-500/20 max-w-md text-center">
+          <h2 className="text-xl font-bold mb-2">Burner Session Failed</h2>
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isInitialized) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="animate-pulse flex flex-col items-center">
+          <div className="w-12 h-12 border-4 border-accent border-t-transparent rounded-full animate-spin mb-4"></div>
+          <p className="text-text-secondary">Establishing Quantum-Secure Burner Session...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full w-full bg-bg-main">
+      <header className="flex items-center justify-between p-4 border-b border-border bg-bg-surface/50 backdrop-blur-md sticky top-0 z-10">
+        <div>
+          <h1 className="text-lg font-bold text-text-primary flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse"></span>
+            Burner Session
+          </h1>
+          <p className="text-xs text-text-secondary">RAM-Only &bull; PQ-DR Encrypted</p>
+        </div>
+      </header>
+
+      <main className="flex-1 overflow-y-auto p-4 space-y-4">
+        {messages.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-text-secondary space-y-2 opacity-50">
+            <svg className="w-12 h-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+            <p>Session is live. Messages are ephemeral.</p>
+          </div>
+        ) : (
+          messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={`flex ${msg.senderId === 'guest' ? 'justify-end' : 'justify-start'}`}
+            >
+              <div
+                className={`max-w-[80%] rounded-2xl px-4 py-2 ${
+                  msg.senderId === 'guest'
+                    ? 'bg-accent text-white rounded-tr-sm'
+                    : 'bg-bg-surface border border-border text-text-primary rounded-tl-sm'
+                }`}
+              >
+                <p className="break-words">{msg.content}</p>
+                <p className="text-[10px] opacity-60 mt-1 text-right">
+                  {new Date(msg.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </p>
+              </div>
+            </div>
+          ))
+        )}
+        <div ref={messagesEndRef} />
+      </main>
+
+      <footer className="p-4 bg-bg-surface/50 border-t border-border">
+        <form onSubmit={handleSend} className="flex gap-2">
+          <input
+            type="text"
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            placeholder="Type an ephemeral message..."
+            className="flex-1 bg-bg-main border border-border rounded-full px-4 py-2 text-text-primary focus:outline-none focus:border-accent transition-colors"
+            autoFocus
+          />
+          <button
+            type="submit"
+            disabled={!inputText.trim()}
+            className="bg-accent hover:bg-accent/90 disabled:opacity-50 text-white rounded-full p-2 w-10 h-10 flex items-center justify-center transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+            </svg>
+          </button>
+        </form>
+      </footer>
+    </div>
+  );
+}

--- a/web/src/store/burner.ts
+++ b/web/src/store/burner.ts
@@ -1,0 +1,213 @@
+import { createWithEqualityFn } from 'zustand/traditional';
+import type { BurnerDoubleRatchetState, BurnerDoubleRatchetHeader } from '../workers/crypto.worker';
+import { getSocket } from '../lib/socket';
+import { worker_burner_dr_init_guest, worker_burner_dr_encrypt, worker_burner_dr_decrypt } from '../lib/crypto-worker-proxy';
+import { getSodiumLib } from '../utils/crypto';
+import { useAuthStore } from './auth';
+
+export type BurnerMessage = {
+  id: string;
+  senderId: string; // 'host' or 'guest'
+  content: string;
+  createdAt: string;
+};
+
+interface BurnerState {
+  roomId: string | null;
+  hostDeviceId: string | null;
+  hostPqPk: string | null;
+  hostClassicalPk: string | null;
+  hostUserId: string | null;
+  
+  // Guest Crypto State (RAM ONLY)
+  drState: BurnerDoubleRatchetState | null;
+  guestClassicalPk: string | null;
+  
+  messages: BurnerMessage[];
+  isInitialized: boolean;
+  error: string | null;
+}
+
+interface BurnerActions {
+  initializeFromHash: (hash: string) => Promise<void>;
+  sendMessage: (content: string) => Promise<void>;
+  receiveMessage: (ciphertext: string) => Promise<void>;
+  reset: () => void;
+}
+
+const initialState: BurnerState = {
+  roomId: null,
+  hostDeviceId: null,
+  hostPqPk: null,
+  hostClassicalPk: null,
+  hostUserId: null,
+  drState: null,
+  guestClassicalPk: null,
+  messages: [],
+  isInitialized: false,
+  error: null,
+};
+
+export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>((set, get) => ({
+  ...initialState,
+
+  reset: () => set(initialState),
+
+  initializeFromHash: async (hash: string) => {
+    try {
+      // Hash format: #<RoomID>_<HostDeviceID>_<HostPQPublicKey>_<HostClassicalPublicKey>_<HostUserId>
+      // Wait, let's include HostUserId so we can route it.
+      // Let's assume hash format is: #<RoomID>:<HostUserId>:<HostDeviceID>:<HostPQPublicKey>:<HostClassicalPublicKey>
+      const cleanHash = hash.replace('#', '');
+      const parts = cleanHash.split(':');
+      if (parts.length < 5) {
+        throw new Error('Invalid burner link format.');
+      }
+      
+      const [roomId, hostUserId, hostDeviceId, hostPqPk, hostClassicalPk] = parts;
+      
+      const sodium = await getSodiumLib();
+      // Ensure we safely decode URL-encoded base64 components
+      const safePqPk = decodeURIComponent(hostPqPk);
+      const safeClassicalPk = decodeURIComponent(hostClassicalPk);
+      
+      const hostClassicalPkBytes = sodium.from_base64(safeClassicalPk, sodium.base64_variants.URLSAFE_NO_PADDING);
+      const hostPqPkBytes = sodium.from_base64(safePqPk, sodium.base64_variants.URLSAFE_NO_PADDING);
+
+      // Initialize Guest Double Ratchet State
+      const { state, guestClassicalPk: guestPk } = await worker_burner_dr_init_guest({
+        hostClassicalPk: hostClassicalPkBytes.buffer,
+        hostPqPk: hostPqPkBytes.buffer
+      });
+
+      set({
+        roomId,
+        hostUserId,
+        hostDeviceId,
+        hostPqPk,
+        hostClassicalPk,
+        drState: state,
+        guestClassicalPk: guestPk,
+        isInitialized: true,
+        error: null
+      });
+      
+      // Optionally, we could send a "Hello, I joined" message here, but we'll leave it to the UI.
+
+    } catch (e) {
+      console.error('Failed to initialize burner session:', e);
+      set({ error: 'Invalid or expired burner link.' });
+    }
+  },
+
+  sendMessage: async (content: string) => {
+    const state = get().drState;
+    const { roomId, hostDeviceId, hostUserId } = get();
+    if (!state || !roomId || !hostDeviceId || !hostUserId) return;
+
+    try {
+      const { state: newState, header, ciphertext } = await worker_burner_dr_encrypt({
+        state,
+        plaintext: content
+      });
+
+      // Update state
+      set({ drState: newState });
+
+      const sodium = await getSodiumLib();
+      const ciphertextB64 = sodium.to_base64(ciphertext, sodium.base64_variants.URLSAFE_NO_PADDING);
+      
+      const payload = {
+        header,
+        ciphertext: ciphertextB64,
+        // Since we are guest, we need to send our guestClassicalPk on the first message so Host knows who we are.
+        // But for simplicity, we can include it in the header or as a separate field.
+        guestClassicalPk: get().guestClassicalPk
+      };
+
+      const socket = getSocket();
+      socket.emit('burner:send', {
+        roomId,
+        targetDeviceId: hostDeviceId,
+        hostUserId,
+        ciphertext: JSON.stringify(payload)
+      }, (res: any) => {
+        if (res && res.ok) {
+          const msg: BurnerMessage = {
+            id: Date.now().toString(),
+            senderId: 'guest',
+            content,
+            createdAt: new Date().toISOString()
+          };
+          set(s => ({ messages: [...s.messages, msg] }));
+        } else {
+          console.error("Failed to send burner message:", res?.error);
+        }
+      });
+    } catch (e) {
+      console.error('Burner encrypt failed:', e);
+    }
+  },
+
+  receiveMessage: async (cipherString: string) => {
+    const state = get().drState;
+    if (!state) return;
+
+    try {
+      const payload = JSON.parse(cipherString);
+      const { header, ciphertext: ciphertextB64 } = payload;
+      
+      const sodium = await getSodiumLib();
+      const ciphertext = sodium.from_base64(ciphertextB64, sodium.base64_variants.URLSAFE_NO_PADDING);
+
+      const { state: newState, plaintext } = await worker_burner_dr_decrypt({
+        state,
+        header: header as BurnerDoubleRatchetHeader,
+        ciphertext: ciphertext.buffer
+      });
+
+      set({ drState: newState });
+
+      const content = new TextDecoder().decode(plaintext);
+      const msg: BurnerMessage = {
+        id: Date.now().toString(),
+        senderId: 'host',
+        content,
+        createdAt: new Date().toISOString()
+      };
+      set(s => ({ messages: [...s.messages, msg] }));
+
+    } catch (e) {
+      console.error('Burner decrypt failed:', e);
+    }
+  }
+}));
+
+// Utility to generate a burner link for the Host
+export async function generateBurnerLink(): Promise<string> {
+  const roomId = `burner_${crypto.randomUUID()}`; 
+  const sodium = await getSodiumLib();
+  
+  // Host keys
+  const authStore = useAuthStore.getState();
+  const myUserId = authStore.user?.id;
+  
+  if (!myUserId) throw new Error("User not authenticated");
+
+  // Fetch current device ID
+  const { authFetch } = await import('../lib/api');
+  const devices = await authFetch<any[]>('/api/users/me/devices');
+  const currentDevice = devices.find(d => d.isCurrent);
+  if (!currentDevice) throw new Error("Could not determine current device ID");
+  const myDeviceId = currentDevice.id;
+
+  const { getMyEncryptionKeyPair } = await import('../utils/crypto');
+  const myDeviceKeys = await getMyEncryptionKeyPair(); // Classical X25519
+  const myPqKeys = await authStore.getPqEncryptionKeyPair();
+  
+  const myPqPkB64 = sodium.to_base64(myPqKeys.publicKey, sodium.base64_variants.URLSAFE_NO_PADDING);
+  const b64Classical = sodium.to_base64(myDeviceKeys.publicKey, sodium.base64_variants.URLSAFE_NO_PADDING);
+
+  // Link format: #<RoomID>:<HostUserId>:<HostDeviceID>:<HostPQPublicKey>:<HostClassicalPublicKey>
+  return `${window.location.origin}/drop/#${roomId}:${myUserId}:${myDeviceId}:${encodeURIComponent(myPqPkB64)}:${encodeURIComponent(b64Classical)}`;
+}

--- a/web/src/store/burner.ts
+++ b/web/src/store/burner.ts
@@ -13,15 +13,12 @@ export type BurnerMessage = {
 };
 
 interface BurnerState {
-  roomId: string | null;
   hostDeviceId: string | null;
   hostPqPk: string | null;
   hostClassicalPk: string | null;
   hostUserId: string | null;
   
-  // Guest Crypto State (RAM ONLY)
-  drState: BurnerDoubleRatchetState | null;
-  guestClassicalPk: string | null;
+  activeSessions: Record<string, { drState: BurnerDoubleRatchetState | null; guestClassicalPk: string | null }>;
   
   messages: BurnerMessage[];
   isInitialized: boolean;
@@ -31,18 +28,17 @@ interface BurnerState {
 interface BurnerActions {
   initializeFromHash: (hash: string) => Promise<void>;
   sendMessage: (content: string) => Promise<void>;
-  receiveMessage: (ciphertext: string) => Promise<void>;
+  receiveMessage: (roomId: string, ciphertext: string) => Promise<void>;
+  destroyBurnerSession: (roomId: string) => void;
   reset: () => void;
 }
 
 const initialState: BurnerState = {
-  roomId: null,
   hostDeviceId: null,
   hostPqPk: null,
   hostClassicalPk: null,
   hostUserId: null,
-  drState: null,
-  guestClassicalPk: null,
+  activeSessions: {},
   messages: [],
   isInitialized: false,
   error: null,
@@ -75,22 +71,23 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
       const hostPqPkBytes = sodium.from_base64(safePqPk, sodium.base64_variants.URLSAFE_NO_PADDING);
 
       // Initialize Guest Double Ratchet State
-      const { state, guestClassicalPk: guestPk } = await worker_burner_dr_init_guest({
+      const { state: stateFromWorker, guestClassicalPk: guestPk } = await worker_burner_dr_init_guest({
         hostClassicalPk: hostClassicalPkBytes.buffer,
         hostPqPk: hostPqPkBytes.buffer
       });
 
-      set({
-        roomId,
+      set(state => ({
         hostUserId,
         hostDeviceId,
         hostPqPk,
         hostClassicalPk,
-        drState: state,
-        guestClassicalPk: guestPk,
+        activeSessions: {
+          ...state.activeSessions,
+          [roomId]: { drState: stateFromWorker, guestClassicalPk: guestPk }
+        },
         isInitialized: true,
         error: null
-      });
+      }));
       
       // Optionally, we could send a "Hello, I joined" message here, but we'll leave it to the UI.
 
@@ -101,9 +98,11 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
   },
 
   sendMessage: async (content: string) => {
-    const state = get().drState;
-    const { roomId, hostDeviceId, hostUserId } = get();
-    if (!state || !roomId || !hostDeviceId || !hostUserId) return;
+    const roomId = Object.keys(get().activeSessions)[0];
+    const session = roomId ? get().activeSessions[roomId] : null;
+    const state = session?.drState;
+    const { hostDeviceId, hostUserId } = get();
+    if (!state || !roomId || !hostDeviceId || !hostUserId || !session) return;
 
     try {
       const { state: newState, header, ciphertext } = await worker_burner_dr_encrypt({
@@ -112,7 +111,12 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
       });
 
       // Update state
-      set({ drState: newState });
+      set(s => ({
+        activeSessions: {
+          ...s.activeSessions,
+          [roomId]: { ...session, drState: newState }
+        }
+      }));
 
       const sodium = await getSodiumLib();
       const ciphertextB64 = sodium.to_base64(ciphertext, sodium.base64_variants.URLSAFE_NO_PADDING);
@@ -122,7 +126,7 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
         ciphertext: ciphertextB64,
         // Since we are guest, we need to send our guestClassicalPk on the first message so Host knows who we are.
         // But for simplicity, we can include it in the header or as a separate field.
-        guestClassicalPk: get().guestClassicalPk
+        guestClassicalPk: session.guestClassicalPk
       };
 
       const socket = getSocket();
@@ -149,14 +153,42 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
     }
   },
 
-  receiveMessage: async (cipherString: string) => {
-    const state = get().drState;
-    if (!state) return;
+  receiveMessage: async (roomId: string, cipherString: string) => {
+    const session = get().activeSessions[roomId] || { drState: null, guestClassicalPk: null };
+    let state = session.drState;
+    let guestPkState = session.guestClassicalPk;
 
     try {
       const payload = JSON.parse(cipherString);
-      const { header, ciphertext: ciphertextB64 } = payload;
-      
+      const { header, ciphertext: ciphertextB64, guestClassicalPk } = payload;
+
+      // Host initialization on first message from Guest
+      if (!state) {
+        if (guestClassicalPk) {
+          const sodium = await getSodiumLib();
+          const { getMyEncryptionKeyPair } = await import('../utils/crypto');
+          const myDeviceKeys = await getMyEncryptionKeyPair(); // Host classical
+          const authStore = useAuthStore.getState();
+          const myPqKeys = await authStore.getPqEncryptionKeyPair(); // Host PQ
+
+          const guestPkBytes = sodium.from_base64(guestClassicalPk, sodium.base64_variants.URLSAFE_NO_PADDING);
+          const savedCtBytes = sodium.from_base64((header as any).ct, sodium.base64_variants.URLSAFE_NO_PADDING);
+          
+          const { worker_burner_dr_init_host } = await import('../lib/crypto-worker-proxy');
+          const initRes = await worker_burner_dr_init_host({
+             hostClassicalSk: myDeviceKeys.privateKey,
+             hostPqSk: myPqKeys.privateKey,
+             guestClassicalPk: guestPkBytes,
+             savedCt: savedCtBytes
+          });
+          
+          state = initRes.state;
+          guestPkState = guestClassicalPk;
+        } else {
+           return; // Cannot decrypt without drState or guestPk
+        }
+      }
+
       const sodium = await getSodiumLib();
       const ciphertext = sodium.from_base64(ciphertextB64, sodium.base64_variants.URLSAFE_NO_PADDING);
 
@@ -166,19 +198,62 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
         ciphertext: ciphertext.buffer
       });
 
-      set({ drState: newState });
+      set(s => ({
+        activeSessions: {
+          ...s.activeSessions,
+          [roomId]: { drState: newState, guestClassicalPk: guestPkState }
+        }
+      }));
 
       const content = new TextDecoder().decode(plaintext);
+      const isHost = !!useAuthStore.getState().user;
       const msg: BurnerMessage = {
         id: Date.now().toString(),
-        senderId: 'host',
+        senderId: isHost ? 'guest' : 'host',
         content,
         createdAt: new Date().toISOString()
       };
+      
+      // If we are Host, push to UI chat list
+      if (isHost) {
+        const { useMessageStore } = await import('./message');
+        const mainMsg = {
+           id: msg.id,
+           conversationId: roomId,
+           senderId: 'guest_user', 
+           content: msg.content,
+           createdAt: msg.createdAt,
+           updatedAt: msg.createdAt,
+           isSilent: false,
+           isEdited: false,
+           isViewOnce: false,
+           isViewed: false
+        };
+        useMessageStore.getState().addOptimisticMessage(roomId, mainMsg as any);
+        
+        const { useConversationStore } = await import('./conversation');
+        useConversationStore.getState().updateConversationLastMessage(roomId, mainMsg as any);
+      }
+
       set(s => ({ messages: [...s.messages, msg] }));
 
     } catch (e) {
       console.error('Burner decrypt failed:', e);
+    }
+  },
+
+  destroyBurnerSession: (roomId: string) => {
+    set(s => {
+      const newSessions = { ...s.activeSessions };
+      delete newSessions[roomId];
+      return { activeSessions: newSessions };
+    });
+    import('./conversation').then(m => {
+      m.useConversationStore.getState().deleteConversation(roomId);
+    });
+    const socket = getSocket();
+    if (socket) {
+      socket.emit('burner:destroy', { roomId });
     }
   }
 }));

--- a/web/src/store/burner.ts
+++ b/web/src/store/burner.ts
@@ -10,6 +10,11 @@ export type BurnerMessage = {
   senderId: string; // 'host' or 'guest'
   content: string;
   createdAt: string;
+  fileUrl?: string;
+  fileName?: string;
+  fileType?: string;
+  fileSize?: number;
+  fileKey?: string;
 };
 
 interface BurnerState {
@@ -29,6 +34,7 @@ interface BurnerActions {
   initializeFromHash: (hash: string) => Promise<void>;
   sendMessage: (content: string) => Promise<void>;
   receiveMessage: (roomId: string, ciphertext: string) => Promise<void>;
+  terminateSession: (reason: string) => void;
   destroyBurnerSession: (roomId: string) => void;
   reset: () => void;
 }
@@ -48,6 +54,10 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
   ...initialState,
 
   reset: () => set(initialState),
+
+  terminateSession: (reason: string) => {
+    set({ error: reason, isInitialized: true, activeSessions: {} });
+  },
 
   initializeFromHash: async (hash: string) => {
     try {
@@ -137,11 +147,31 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
         ciphertext: JSON.stringify(payload)
       }, (res: any) => {
         if (res && res.ok) {
+          let parsedContent = content;
+          let fileData = {};
+
+          if (content.startsWith('{')) {
+            try {
+              const data = JSON.parse(content);
+              if (data.type === 'file') {
+                parsedContent = data.text || '';
+                fileData = {
+                  fileUrl: data.fileUrl,
+                  fileName: data.fileName,
+                  fileType: data.fileType,
+                  fileSize: data.fileSize,
+                  fileKey: data.fileKey
+                };
+              }
+            } catch (e) {}
+          }
+
           const msg: BurnerMessage = {
             id: Date.now().toString(),
             senderId: 'guest',
-            content,
-            createdAt: new Date().toISOString()
+            content: parsedContent,
+            createdAt: new Date().toISOString(),
+            ...fileData
           };
           set(s => ({ messages: [...s.messages, msg] }));
         } else {
@@ -154,6 +184,8 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
   },
 
   receiveMessage: async (roomId: string, cipherString: string) => {
+    if (localStorage.getItem('burned_' + roomId)) return; // Reject zombie messages
+
     const session = get().activeSessions[roomId] || { drState: null, guestClassicalPk: null };
     let state = session.drState;
     let guestPkState = session.guestClassicalPk;
@@ -206,12 +238,34 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
       }));
 
       const content = new TextDecoder().decode(plaintext);
+      let parsedContent = content;
+      let fileData = {};
+
+      if (content.startsWith('{')) {
+        try {
+          const data = JSON.parse(content);
+          if (data.type === 'file') {
+            parsedContent = data.text || '';
+            fileData = {
+              fileUrl: data.fileUrl,
+              fileName: data.fileName,
+              fileType: data.fileType,
+              fileSize: data.fileSize,
+              fileKey: data.fileKey
+            };
+          }
+        } catch (e) {
+          console.warn('Failed to parse message JSON:', e);
+        }
+      }
+
       const isHost = !!useAuthStore.getState().user;
       const msg: BurnerMessage = {
         id: Date.now().toString(),
         senderId: isHost ? 'guest' : 'host',
-        content,
-        createdAt: new Date().toISOString()
+        content: parsedContent,
+        createdAt: new Date().toISOString(),
+        ...fileData
       };
       
       // If we are Host, push to UI chat list
@@ -227,7 +281,8 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
            isSilent: false,
            isEdited: false,
            isViewOnce: false,
-           isViewed: false
+           isViewed: false,
+           ...fileData
         };
         useMessageStore.getState().addOptimisticMessage(roomId, mainMsg as any);
         
@@ -242,18 +297,34 @@ export const useBurnerStore = createWithEqualityFn<BurnerState & BurnerActions>(
     }
   },
 
-  destroyBurnerSession: (roomId: string) => {
+  destroyBurnerSession: async (roomId: string) => {
+    localStorage.setItem('burned_' + roomId, 'true'); // Local blacklist
+    
+    // 1. Remove from burner active sessions
     set(s => {
       const newSessions = { ...s.activeSessions };
       delete newSessions[roomId];
       return { activeSessions: newSessions };
     });
-    import('./conversation').then(m => {
-      m.useConversationStore.getState().deleteConversation(roomId);
-    });
+
+    // 2. Local-only conversation cleanup (Host/Guest UI)
+    const { useConversationStore } = await import('./conversation');
+    await useConversationStore.getState().deleteConversation(roomId);
+
+    // 3. Clear RAM messages
+    const { useMessageStore } = await import('./message');
+    useMessageStore.getState().clearMessagesForConversation(roomId);
+
+    // 4. Emit to server for blacklist reinforcement
     const socket = getSocket();
     if (socket) {
       socket.emit('burner:destroy', { roomId });
+    }
+
+    // 5. Atomic Redirection
+    window.location.hash = '';
+    if (window.location.pathname.includes('/drop')) {
+       window.location.href = '/chat';
     }
   }
 }));

--- a/web/src/store/conversation.ts
+++ b/web/src/store/conversation.ts
@@ -281,6 +281,23 @@ export const useConversationStore = createWithEqualityFn<State & Actions>((set, 
   },
 
   deleteConversation: async (id) => {
+    if (id.startsWith('burner_')) {
+      set((state) => {
+        const newConvos = state.conversations.filter(c => c.id !== id);
+        return { 
+          conversations: newConvos,
+          activeId: state.activeId === id ? null : state.activeId,
+          isSidebarOpen: state.activeId === id ? true : state.isSidebarOpen
+        };
+      });
+      try {
+        const { shadowVault } = await import('@lib/shadowVaultDb');
+        await shadowVault.deleteConversation(id);
+      } catch (e) {
+        console.error("Failed to delete burner conversation from local DB", e);
+      }
+      return;
+    }
     try {
       await authFetch(`/api/conversations/${id}`, { method: 'DELETE' });
       get().removeConversation(id);

--- a/web/src/store/message.ts
+++ b/web/src/store/message.ts
@@ -958,6 +958,70 @@ export const useMessageStore = createWithEqualityFn<State & Actions>((set, get) 
     const { user, hasRestoredKeys } = useAuthStore.getState();
     if (!user) return;
 
+    if (conversationId.startsWith('burner_')) {
+      const actualTempId = tempId !== undefined ? tempId : generateTempId();
+      
+      const { useBurnerStore } = await import('./burner');
+      const burnerState = useBurnerStore.getState();
+      const session = burnerState.activeSessions[conversationId];
+      const state = session?.drState;
+
+      if (!state) {
+        toast.error("Waiting for guest to connect first.");
+        return;
+      }
+      
+      let lastMsgPreview = data.content;
+      try {
+         if (lastMsgPreview?.startsWith('{') && lastMsgPreview.includes('"type":"file"')) {
+             lastMsgPreview = '📎 Sent a file';
+         }
+      } catch {}
+
+      const msg = {
+          id: `temp_${actualTempId}` as any, tempId: actualTempId, optimistic: true,
+          content: data.content, senderId: user.id as any, sender: user,
+          createdAt: new Date().toISOString(), conversationId: conversationId as any, status: 'SENDING',
+          isSilent: isSilent
+      } as Message;
+
+      if (!isSilent) {
+        get().addOptimisticMessage(conversationId, msg);
+        const { useConversationStore } = await import('./conversation');
+        useConversationStore.getState().updateConversationLastMessage(conversationId, { ...msg, content: lastMsgPreview, fileType: data.fileType, fileName: data.fileName } as any);
+      }
+      
+      try {
+        const { worker_burner_dr_encrypt } = await import('../lib/crypto-worker-proxy');
+        const { state: newState, header, ciphertext } = await worker_burner_dr_encrypt({
+          state,
+          plaintext: data.content || ""
+        });
+        useBurnerStore.setState((s) => ({
+          activeSessions: {
+            ...s.activeSessions,
+            [conversationId]: { ...session, drState: newState }
+          }
+        }));
+        
+        const { getSodiumLib } = await import('../utils/crypto');
+        const sodium = await getSodiumLib();
+        const ciphertextB64 = sodium.to_base64(ciphertext, sodium.base64_variants.URLSAFE_NO_PADDING);
+        const payload = { header, ciphertext: ciphertextB64 };
+        
+        const socket = (await import('../lib/socket')).getSocket();
+        socket.emit('burner:reply', { roomId: conversationId, ciphertext: JSON.stringify(payload) });
+        
+        // Update local status to SENT
+        get().updateMessage(conversationId, `temp_${actualTempId}`, { status: 'SENT' });
+      } catch (e) {
+        console.error('Burner encrypt failed:', e);
+        toast.error("Failed to send burner message");
+        get().updateMessage(conversationId, `temp_${actualTempId}`, { error: true });
+      }
+      return;
+    }
+
     // FAKE SEND FOR DECOY
     if (sessionStorage.getItem('nyx_decoy_mode') === 'true') {
         const actualTempId = tempId !== undefined ? tempId : Date.now();
@@ -1645,6 +1709,8 @@ export const useMessageStore = createWithEqualityFn<State & Actions>((set, get) 
   },
 
   loadMessagesForConversation: async (id) => {
+    if (id.startsWith('burner_')) return;
+
     if (sessionStorage.getItem('nyx_decoy_mode') === 'true') {
        set(state => ({
           messages: { ...state.messages, [id]: [{ id: 'msg-1', content: 'Welcome to NYX. No active chats found.', senderId: 'bot-1', createdAt: new Date().toISOString(), conversationId: id, type: 'SYSTEM' } as Message] },
@@ -1752,6 +1818,8 @@ export const useMessageStore = createWithEqualityFn<State & Actions>((set, get) 
   },
 
   loadPreviousMessages: async (conversationId) => {
+    if (conversationId.startsWith('burner_')) return;
+
     const { isFetchingMore, hasMore, messages } = get();
     if (isFetchingMore[conversationId] || !hasMore[conversationId]) return;
     

--- a/web/src/store/messageInput.ts
+++ b/web/src/store/messageInput.ts
@@ -209,8 +209,9 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
       updateActivity(activityId, { progress: 30, fileName: `Uploading ${file.name}...` });
       
       const fileRetention = expiresIn ? expiresIn : (isViewOnce ? 1209600 : 0);
+      const endpoint = conversationId.startsWith('burner_') ? '/api/uploads/burner-presigned' : '/api/uploads/presigned';
 
-      const presignedRes = await api<{ uploadUrl: string, publicUrl: string, key: string }>('/api/uploads/presigned', {
+      const presignedRes = await api<{ uploadUrl: string, publicUrl: string, key: string }>(endpoint, {
           method: 'POST',
           body: JSON.stringify({
               fileName: file.name,
@@ -326,8 +327,9 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
       updateActivity(activityId, { progress: 40, fileName: 'Uploading voice...' });
       
       const fileRetention = expiresIn ? expiresIn : (isViewOnce ? 1209600 : 0);
+      const endpoint = conversationId.startsWith('burner_') ? '/api/uploads/burner-presigned' : '/api/uploads/presigned';
 
-      const presignedRes = await api<{ uploadUrl: string, publicUrl: string, key: string }>('/api/uploads/presigned', {
+      const presignedRes = await api<{ uploadUrl: string, publicUrl: string, key: string }>(endpoint, {
           method: 'POST',
           body: JSON.stringify({
               fileName: "voice-message.webm",

--- a/web/src/store/messageInput.ts
+++ b/web/src/store/messageInput.ts
@@ -155,14 +155,15 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
     // FIX 1: Extract functions correctly
     const { addOptimisticMessage, updateMessage, sendMessage: coreSendMessage } = useMessageStore.getState();
     const me = useAuthStore.getState().user;
+    const isGuestBurner = !me && conversationId.startsWith('burner_');
     
-    if (!me) {
+    if (!me && !isGuestBurner) {
       removeActivity(activityId);
       toast.error(i18n.t('errors:user_not_authenticated', 'User not authenticated.'));
       return;
     }
 
-    if (!await ensureGroupSessionIfNeeded(conversationId)) {
+    if (!isGuestBurner && !await ensureGroupSessionIfNeeded(conversationId)) {
       removeActivity(activityId);
       return;
     }
@@ -171,23 +172,25 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
     const expiresAt = expiresIn ? new Date(Date.now() + expiresIn * 1000).toISOString() : null;
 
     // FIX 2: Use underscore for tempId consistency (temp_12345)
-    const optimisticMessage: Message = {
-      id: asMessageId(`temp_${tempId}`),
-      tempId,
-      conversationId: asConversationId(conversationId),
-      senderId: asUserId(me.id),
-      sender: me,
-      createdAt: new Date().toISOString(),
-      optimistic: true,
-      fileUrl: URL.createObjectURL(file), 
-      fileName: file.name,
-      fileType: file.type,
-      fileSize: file.size,
-      expiresAt,
-      repliedTo: replyingTo || undefined,
-      isViewOnce,
-    };
-    addOptimisticMessage(conversationId, optimisticMessage);
+    if (!isGuestBurner) {
+      const optimisticMessage: Message = {
+        id: asMessageId(`temp_${tempId}`),
+        tempId,
+        conversationId: asConversationId(conversationId),
+        senderId: asUserId(me!.id),
+        sender: me!,
+        createdAt: new Date().toISOString(),
+        optimistic: true,
+        fileUrl: URL.createObjectURL(file), 
+        fileName: file.name,
+        fileType: file.type,
+        fileSize: file.size,
+        expiresAt,
+        repliedTo: replyingTo || undefined,
+        isViewOnce,
+      };
+      addOptimisticMessage(conversationId, optimisticMessage);
+    }
     
     set({ replyingTo: null, isViewOnce: false, isHD: false });
 
@@ -280,13 +283,14 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
     // FIX 5: Extract functions correctly
     const { addOptimisticMessage, updateMessage, sendMessage: coreSendMessage } = useMessageStore.getState();
     const me = useAuthStore.getState().user;
+    const isGuestBurner = !me && conversationId.startsWith('burner_');
     
-    if (!me) {
+    if (!me && !isGuestBurner) {
       removeActivity(activityId);
       return;
     }
     
-    if (!await ensureGroupSessionIfNeeded(conversationId)) {
+    if (!isGuestBurner && !await ensureGroupSessionIfNeeded(conversationId)) {
       removeActivity(activityId);
       return;
     }
@@ -295,25 +299,27 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
     const expiresAt = expiresIn ? new Date(Date.now() + expiresIn * 1000).toISOString() : null;
 
     // FIX 6: Use underscore for tempId consistency (temp_12345)
-    const optimisticMessage: Message = {
-      id: asMessageId(`temp_${tempId}`),
-      tempId,
-      conversationId: asConversationId(conversationId),
-      senderId: asUserId(me.id),
-      sender: me,
-      createdAt: new Date().toISOString(),
-      optimistic: true,
-      fileUrl: URL.createObjectURL(blob),
-      fileName: "voice-message.webm",
-      fileType: "audio/webm",
-      fileSize: blob.size,
-      duration,
-      expiresAt,
-      repliedTo: replyingTo || undefined,
-      isViewOnce,
-    };
-    
-    addOptimisticMessage(conversationId, optimisticMessage);
+    if (!isGuestBurner) {
+      const optimisticMessage: Message = {
+        id: asMessageId(`temp_${tempId}`),
+        tempId,
+        conversationId: asConversationId(conversationId),
+        senderId: asUserId(me!.id),
+        sender: me!,
+        createdAt: new Date().toISOString(),
+        optimistic: true,
+        fileUrl: URL.createObjectURL(blob),
+        fileName: "voice-message.webm",
+        fileType: "audio/webm",
+        fileSize: blob.size,
+        duration,
+        expiresAt,
+        repliedTo: replyingTo || undefined,
+        isViewOnce,
+      };
+      
+      addOptimisticMessage(conversationId, optimisticMessage);
+    }
     set({ replyingTo: null, isViewOnce: false });
 
     try {
@@ -367,13 +373,18 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
           duration
       };
 
-      await coreSendMessage(conversationId, {
-          content: JSON.stringify(metadata),
-          repliedToId: replyingTo?.id || undefined,
-          repliedTo: replyingTo || undefined,
-          expiresAt: expiresIn ? new Date(Date.now() + expiresIn * 1000).toISOString() : undefined,
-          isViewOnce
-      }, tempId);
+      if (isGuestBurner) {
+        const { useBurnerStore } = await import('./burner');
+        await useBurnerStore.getState().sendMessage(JSON.stringify(metadata));
+      } else {
+        await coreSendMessage(conversationId, {
+            content: JSON.stringify(metadata),
+            repliedToId: replyingTo?.id || undefined,
+            repliedTo: replyingTo || undefined,
+            expiresAt: expiresIn ? new Date(Date.now() + expiresIn * 1000).toISOString() : undefined,
+            isViewOnce
+        }, tempId);
+      }
       
       updateActivity(activityId, { progress: 100, fileName: 'Sent!' });
       setTimeout(() => removeActivity(activityId), 1000); 
@@ -383,7 +394,9 @@ export const useMessageInputStore = createWithEqualityFn<State>((set, get) => ({
       toast.error(i18n.t('errors:voice_message_failed', `Voice message failed: ${errorMsg}`, { error: errorMsg }));
       removeActivity(activityId);
       // FIX 7: Use consistent temp_ prefix
-      updateMessage(conversationId, `temp_${tempId}`, { error: true, optimistic: false });
+      if (!isGuestBurner) {
+        updateMessage(conversationId, `temp_${tempId}`, { error: true, optimistic: false });
+      }
     }
   },
 

--- a/web/src/workers/crypto.worker.ts
+++ b/web/src/workers/crypto.worker.ts
@@ -1994,7 +1994,11 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
         try {
           const stateKemRBytes = state.KEMr ? b64ToBytes(state.KEMr) : null;
 
-          if (!stateKemRBytes || sodium.compare(headerKemPk, stateKemRBytes) !== 0) {
+          const isNewKey = !stateKemRBytes || 
+                           (headerKemPk.length !== stateKemRBytes.length) || 
+                           (sodium.compare(headerKemPk, stateKemRBytes) !== 0);
+
+          if (isNewKey) {
             // PRE-RATCHET SKIP LOOP
             const MAX_SKIP = 1000;
             if (header.pn - state.Nr > MAX_SKIP) {

--- a/web/src/workers/crypto.worker.ts
+++ b/web/src/workers/crypto.worker.ts
@@ -314,6 +314,26 @@ function serializeState(runtime: RuntimeDoubleRatchetState): DoubleRatchetState 
 
 // --- MAIN MESSAGE HANDLER ---
 
+export interface BurnerDoubleRatchetState {
+  RK: string | null;
+  CKs: string | null;
+  CKr: string | null;
+  KEMs_pub: string | null;
+  KEMs_priv: string | null;
+  KEMr: string | null;
+  savedCt: string | null;
+  Ns: number;
+  Nr: number;
+  PN: number;
+}
+
+export interface BurnerDoubleRatchetHeader {
+  kemPk: string;
+  ct: string;
+  n: number;
+  pn: number;
+}
+
 export type WorkerMessage =
   | { type: 'DERIVE_KEY'; payload: { password: string; salt: CryptoBuffer }; id: string }
   | { type: 'ENCRYPT_DATA'; payload: { keyBytes: CryptoBuffer; data: unknown }; id: string }
@@ -352,7 +372,11 @@ export type WorkerMessage =
   | { type: 'group_init_sender_key'; payload: void; id: string }
   | { type: 'group_ratchet_encrypt'; payload: { serializedState: GroupRatchetState; plaintext: string | CryptoBuffer; signingPrivateKey: CryptoBuffer }; id: string }
   | { type: 'group_ratchet_decrypt'; payload: { serializedState: GroupRatchetState; header: GroupRatchetHeader; ciphertext: CryptoBuffer; signature: string; senderSigningPublicKey: CryptoBuffer }; id: string }
-  | { type: 'group_decrypt_skipped'; payload: { mk: string; headerN: number; ciphertext: CryptoBuffer; signature: string; senderSigningPublicKey: CryptoBuffer }; id: string };
+  | { type: 'group_decrypt_skipped'; payload: { mk: string; headerN: number; ciphertext: CryptoBuffer; signature: string; senderSigningPublicKey: CryptoBuffer }; id: string }
+  | { type: 'burner_dr_init_guest'; payload: { hostClassicalPk: CryptoBuffer; hostPqPk: CryptoBuffer }; id: string }
+  | { type: 'burner_dr_init_host'; payload: { guestClassicalPk: CryptoBuffer; hostClassicalSk: CryptoBuffer; savedCt: CryptoBuffer; hostPqSk: CryptoBuffer }; id: string }
+  | { type: 'burner_dr_encrypt'; payload: { state: BurnerDoubleRatchetState; plaintext: string | CryptoBuffer }; id: string }
+  | { type: 'burner_dr_decrypt'; payload: { state: BurnerDoubleRatchetState; header: BurnerDoubleRatchetHeader; ciphertext: CryptoBuffer }; id: string };
 
 self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
   const { type, payload, id } = event.data;
@@ -1790,6 +1814,302 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
         }
         break;
       }
+      // --- BURNER PROTOCOL (EXCLUSIVE PQ-DR) ---
+
+      case 'burner_dr_init_guest': {
+        const { hostClassicalPk, hostPqPk } = payload as { hostClassicalPk: CryptoBuffer, hostPqPk: CryptoBuffer };
+        const hCPK = new Uint8Array(hostClassicalPk);
+        const hPQPK = new Uint8Array(hostPqPk);
+        
+        let pqKeypair: { publicKey: Uint8Array, privateKey: Uint8Array } | null = null;
+        let guestClassicalKeypair: SodiumKeyPair | null = null;
+
+        try {
+          pqKeypair = sodium.crypto_kem_xwing_keypair();
+          guestClassicalKeypair = sodium.crypto_box_keypair();
+          
+          if (!pqKeypair || !guestClassicalKeypair) {
+             throw new Error("Keypair generation failed");
+          }
+
+          // Encapsulate ke Host (PQ)
+          const pqResult = sodium.crypto_kem_xwing_enc(hPQPK);
+          
+          // Key Exchange Klasik (X25519)
+          const classicalShared = sodium.crypto_scalarmult(guestClassicalKeypair.privateKey, hCPK);
+          
+          // Gabungkan (Hybrid PQ-DR Root Key)
+          const combinedSecret = new Uint8Array(classicalShared.length + pqResult.sharedSecret.length);
+          combinedSecret.set(classicalShared, 0);
+          combinedSecret.set(pqResult.sharedSecret, classicalShared.length);
+
+          const KDF = sodium.crypto_generichash(64, combinedSecret, null);
+          
+          const state: BurnerDoubleRatchetState = {
+            RK: bytesToB64(KDF.slice(0, 32)) || null,
+            CKs: bytesToB64(KDF.slice(32, 64)) || null,
+            CKr: null,
+            KEMs_pub: pqKeypair ? bytesToB64(pqKeypair.publicKey) || null : null,
+            KEMs_priv: pqKeypair ? bytesToB64(pqKeypair.privateKey) || null : null,
+            KEMr: bytesToB64(hPQPK) || null,
+            savedCt: bytesToB64(pqResult.ciphertext) || null,
+            Ns: 0, Nr: 0, PN: 0
+          };
+          
+          result = { 
+            state, 
+            guestClassicalPk: guestClassicalKeypair && guestClassicalKeypair.publicKey ? bytesToB64(new Uint8Array(guestClassicalKeypair.publicKey as Iterable<number>)) || '' : ''
+          };
+          
+          sodium.memzero(KDF);
+          sodium.memzero(combinedSecret);
+        } finally {
+           // Bersihkan memori worker
+           if (pqKeypair) sodium.memzero(pqKeypair.privateKey);
+           if (guestClassicalKeypair) sodium.memzero(guestClassicalKeypair.privateKey);
+           sodium.memzero(hCPK);
+           sodium.memzero(hPQPK);
+        }
+        break;
+      }
+
+      case 'burner_dr_init_host': {
+        const { guestClassicalPk, hostClassicalSk, savedCt, hostPqSk } = payload as { guestClassicalPk: CryptoBuffer, hostClassicalSk: CryptoBuffer, savedCt: CryptoBuffer, hostPqSk: CryptoBuffer };
+        const gCPK = new Uint8Array(guestClassicalPk);
+        const hCSK = new Uint8Array(hostClassicalSk);
+        const ct = new Uint8Array(savedCt);
+        const hPQSK = new Uint8Array(hostPqSk);
+
+        try {
+          // Decapsulate dari Guest (PQ)
+          const pqSharedSecret = sodium.crypto_kem_xwing_dec(ct, hPQSK);
+
+          // Key Exchange Klasik (X25519)
+          const classicalShared = sodium.crypto_scalarmult(hCSK, gCPK);
+
+          // Gabungkan
+          const combinedSecret = new Uint8Array(classicalShared.length + pqSharedSecret.length);
+          combinedSecret.set(classicalShared, 0);
+          combinedSecret.set(pqSharedSecret, classicalShared.length);
+
+          const KDF = sodium.crypto_generichash(64, combinedSecret, null);
+
+          const state: BurnerDoubleRatchetState = {
+            RK: bytesToB64(KDF.slice(0, 32)) || null,
+            CKs: null,
+            CKr: bytesToB64(KDF.slice(32, 64)) || null,
+            KEMs_pub: null,
+            KEMs_priv: null,
+            KEMr: bytesToB64(gCPK) || null, // Not strictly correct, KEMr should be guest PQ PK if they ever sent one, but guest sent ct and generated ephemeral KEM
+            savedCt: null,
+            Ns: 0, Nr: 0, PN: 0
+          };
+
+          result = { state };
+
+          sodium.memzero(KDF);
+          sodium.memzero(combinedSecret);
+          sodium.memzero(pqSharedSecret);
+          sodium.memzero(classicalShared);
+        } finally {
+          sodium.memzero(gCPK);
+          sodium.memzero(hCSK);
+          sodium.memzero(ct);
+          sodium.memzero(hPQSK);
+        }
+        break;
+      }
+
+      case 'burner_dr_encrypt': {
+        const { state: serializedState, plaintext } = payload as { state: BurnerDoubleRatchetState, plaintext: CryptoBuffer | string };
+        const state = { ...serializedState };
+        const plaintextBytes = typeof plaintext === 'string' ? new TextEncoder().encode(plaintext) : new Uint8Array(plaintext);
+
+        let mk: Uint8Array | null = null;
+        let nonce: Uint8Array | null = null;
+        let ciphertext: Uint8Array | null = null;
+        const cksBytes = state.CKs ? b64ToBytes(state.CKs) : null;
+
+        try {
+          if (!cksBytes) throw new Error("Cannot encrypt: CKs is null");
+
+          const [newCKs, messageKey] = await kdfChain(cksBytes);
+          sodium.memzero(cksBytes);
+          state.CKs = bytesToB64(newCKs) || null;
+          mk = messageKey;
+
+          nonce = sodium.randombytes_buf(24);
+          ciphertext = sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(plaintextBytes, null, null, nonce, mk);
+          
+          if (!nonce || !ciphertext) throw new Error("Encryption failed");
+
+          const combined = new Uint8Array(nonce.length + ciphertext.length);
+          combined.set(nonce);
+          combined.set(ciphertext, nonce.length);
+
+          const header: BurnerDoubleRatchetHeader = {
+            kemPk: state.KEMs_pub || '',
+            ct: state.savedCt || '',
+            n: state.Ns,
+            pn: state.PN
+          };
+
+          state.Ns += 1;
+
+          result = {
+            state,
+            header,
+            ciphertext: Array.from(combined),
+            mk: Array.from(mk)
+          };
+        } finally {
+          if (mk) sodium.memzero(mk);
+          if (nonce) sodium.memzero(nonce);
+          if (ciphertext) sodium.memzero(ciphertext);
+          sodium.memzero(plaintextBytes);
+        }
+        break;
+      }
+
+      case 'burner_dr_decrypt': {
+        const { state: serializedState, header, ciphertext } = payload as { state: BurnerDoubleRatchetState, header: BurnerDoubleRatchetHeader, ciphertext: CryptoBuffer };
+        const state = { ...serializedState };
+        const ciphertextBytes = new Uint8Array(ciphertext);
+        const headerKemPk = header.kemPk ? b64ToBytes(header.kemPk) : null;
+        const headerCt = header.ct ? b64ToBytes(header.ct) : null;
+        
+        if (!headerKemPk) throw new Error("Missing kemPk in header");
+        if (!state.RK) throw new Error("RK is missing");
+
+        const rkBytes = b64ToBytes(state.RK);
+        if (!rkBytes) throw new Error("RK invalid format");
+
+        const skippedKeys: { kemPk: string, n: number, mk: string }[] = [];
+        let mk: Uint8Array | null = null;
+        let sharedSecret1: Uint8Array | null = null;
+        let sharedSecret2: Uint8Array | null = null;
+        let newKEMs: { publicKey: Uint8Array, privateKey: Uint8Array } | null = null;
+        let plaintext: Uint8Array | null = null;
+
+        try {
+          const stateKemRBytes = state.KEMr ? b64ToBytes(state.KEMr) : null;
+
+          if (!stateKemRBytes || sodium.compare(headerKemPk, stateKemRBytes) !== 0) {
+            // PRE-RATCHET SKIP LOOP
+            const MAX_SKIP = 1000;
+            if (header.pn - state.Nr > MAX_SKIP) {
+              throw new Error(`Too many skipped messages: ${header.pn - state.Nr}`);
+            }
+
+            let ckrBytes = state.CKr ? b64ToBytes(state.CKr) : null;
+            if (ckrBytes && state.KEMr) {
+              while (state.Nr < header.pn) {
+                const [nextCKr, skippedMK] = await kdfChain(ckrBytes);
+                skippedKeys.push({ kemPk: state.KEMr, n: state.Nr, mk: bytesToB64(skippedMK) || '' });
+                sodium.memzero(ckrBytes);
+                ckrBytes = nextCKr;
+                state.Nr++;
+              }
+              state.CKr = bytesToB64(ckrBytes) || null;
+            }
+
+            if (headerCt && state.KEMs_priv) {
+              const kemsPrivBytes = b64ToBytes(state.KEMs_priv);
+              if (kemsPrivBytes) {
+                const pqSharedSecret = sodium.crypto_kem_xwing_dec(headerCt, kemsPrivBytes);
+                sharedSecret1 = new Uint8Array(32 + pqSharedSecret.length);
+                sharedSecret1.set(rkBytes, 0);
+                sharedSecret1.set(pqSharedSecret, 32);
+
+                const KDF1 = sodium.crypto_generichash(64, sharedSecret1, null);
+                
+                rkBytes.set(KDF1.slice(0, 32));
+                state.RK = bytesToB64(rkBytes) || null;
+                state.CKr = bytesToB64(KDF1.slice(32, 64)) || null;
+                
+                sodium.memzero(pqSharedSecret);
+                sodium.memzero(KDF1);
+                sodium.memzero(kemsPrivBytes);
+              }
+            }
+
+            state.PN = state.Ns;
+            state.Ns = 0;
+            state.Nr = 0;
+            state.KEMr = header.kemPk;
+
+            newKEMs = sodium.crypto_kem_xwing_keypair();
+            if (!newKEMs) throw new Error("KEM Keypair generation failed");
+            const pqResult = sodium.crypto_kem_xwing_enc(headerKemPk);
+            state.savedCt = bytesToB64(pqResult.ciphertext) || null;
+
+            sharedSecret2 = new Uint8Array(32 + pqResult.sharedSecret.length);
+            sharedSecret2.set(rkBytes, 0);
+            sharedSecret2.set(pqResult.sharedSecret, 32);
+
+            const KDF2 = sodium.crypto_generichash(64, sharedSecret2, null);
+            rkBytes.set(KDF2.slice(0, 32));
+            state.RK = bytesToB64(rkBytes) || null;
+            state.CKs = bytesToB64(KDF2.slice(32, 64)) || null;
+            
+            sodium.memzero(pqResult.sharedSecret);
+            sodium.memzero(KDF2);
+
+            state.KEMs_pub = bytesToB64(newKEMs.publicKey) || null;
+            state.KEMs_priv = bytesToB64(newKEMs.privateKey) || null;
+          }
+
+          const MAX_SKIP = 1000;
+          if (header.n - state.Nr > MAX_SKIP) {
+            throw new Error(`Too many skipped messages: ${header.n - state.Nr}`);
+          }
+
+          let ckrBytes = state.CKr ? b64ToBytes(state.CKr) : null;
+          while (state.Nr < header.n) {
+            if (!ckrBytes) throw new Error("CKr is missing");
+            const [nextCKr, skippedMK] = await kdfChain(ckrBytes);
+            skippedKeys.push({ kemPk: header.kemPk, n: state.Nr, mk: bytesToB64(skippedMK) || '' });
+            sodium.memzero(ckrBytes);
+            ckrBytes = nextCKr;
+            state.Nr++;
+          }
+
+          if (state.Nr === header.n) {
+            if (!ckrBytes) throw new Error("CKr is missing");
+            const [nextCKr, messageKey] = await kdfChain(ckrBytes);
+            mk = messageKey;
+            sodium.memzero(ckrBytes);
+            ckrBytes = nextCKr;
+            state.Nr++;
+          } else {
+            throw new Error("Message N is older than current state");
+          }
+          state.CKr = bytesToB64(ckrBytes) || null;
+
+          const nonce = ciphertextBytes.slice(0, 24);
+          const ctext = ciphertextBytes.slice(24);
+          plaintext = sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(null, ctext, null, nonce, mk);
+          if (!plaintext) throw new Error("Decryption failed");
+
+          result = {
+            state,
+            plaintext: Array.from(plaintext),
+            skippedKeys,
+            mk: Array.from(mk)
+          };
+        } finally {
+          if (sharedSecret1) sodium.memzero(sharedSecret1);
+          if (sharedSecret2) sodium.memzero(sharedSecret2);
+          if (mk) sodium.memzero(mk);
+          if (headerKemPk) sodium.memzero(headerKemPk);
+          if (headerCt) sodium.memzero(headerCt);
+          if (newKEMs) sodium.memzero(newKEMs.privateKey);
+          if (plaintext) sodium.memzero(plaintext);
+          if (rkBytes) sodium.memzero(rkBytes);
+        }
+        break;
+      }
+
       default:
         self.postMessage({ type: 'error', id, error: `Unknown worker command: ${type}` });
         return;


### PR DESCRIPTION
## 🎯 Operation Summary
Fixes # (issue number)

## 🛡️ Protocol Checklist
- [x] I have read the `CONTRIBUTING.md` document.
- [ ] My code strictly adheres to the ESLint v10 Flat Config rules (`pnpm run lint` passes, except unused-vars can be ignored).
- [x] I have NOT modified `libsodium-wrappers` or cryptographic logic (unless this PR is explicitly for a security patch).
- [x] I have tested this locally (Server + Web build successfully).
- [x] I have not introduced any React infinite loops (Zustand v5 selector compliance).

## 🔬 Technical Details (Optional but Recommended)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Burner Chat—temporary, encrypted one-to-one conversations with unique guest links accessible at `/drop`
  * Added encrypted file upload and attachment support in burner sessions
  * Added ability to terminate burner chat sessions

* **Chores**
  * Updated global stylesheet imports across marketing pages for consistent styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->